### PR TITLE
Allow kubeconfig to be passed in for out-of-cluster usage

### DIFF
--- a/kubernetes_wrapper/__init__.py
+++ b/kubernetes_wrapper/__init__.py
@@ -3,7 +3,7 @@ from .k8s_client_wrapper import KubernetesClientWrapper
 
 
 class Kubernetes(RetryWrapper):
-    def __init__(self, namespace):
-        super().__init__(KubernetesClientWrapper(namespace), Exception)
+    def __init__(self, namespace, kubeconfig=None):
+        super().__init__(KubernetesClientWrapper(namespace, kubeconfig), Exception)
         # TODO we could be a bit more specific with the exceptions where we
         # retry

--- a/kubernetes_wrapper/k8s_client_wrapper.py
+++ b/kubernetes_wrapper/k8s_client_wrapper.py
@@ -6,8 +6,11 @@ from inflection import underscore
 
 
 class KubernetesClientWrapper:
-    def __init__(self, namespace):
-        kubernetes.config.load_incluster_config()
+    def __init__(self, namespace, kubeconfig=None):
+        if kubeconfig:
+            kubernetes.config.load_kube_config(kubeconfig)
+        else:
+            kubernetes.config.load_incluster_config()
         self.api_client = kubernetes.client.ApiClient
         self.namespace = namespace
 


### PR DESCRIPTION
This makes it possible to use kubernetes-rapper from outside of the Kubernetes cluster, e.g. in integration tests with pytest-operator.